### PR TITLE
Removed extra "," from Sample Input blocks

### DIFF
--- a/code/csv-filter.md
+++ b/code/csv-filter.md
@@ -155,8 +155,7 @@ One string has 2 dates, the second one has only the year.
            {
              "text": "I live in the United States of America"
            }
-      },      
-      
+      }
     ]
 }
 ```

--- a/code/csv-lookup.md
+++ b/code/csv-lookup.md
@@ -165,8 +165,7 @@ One string has 2 dates, the second one has only the year.
            {
              "text": "I live in the United States of America"
            }
-      },      
-      
+      }
     ]
 }
 ```

--- a/code/dates-extractor.md
+++ b/code/dates-extractor.md
@@ -163,8 +163,7 @@ One string has 2 dates, the second one has only the year.
            {
              "text": "I was born in 1974"
            }
-      },      
-      
+      }
     ]
 }
 ```

--- a/code/strings-cleaner.md
+++ b/code/strings-cleaner.md
@@ -134,8 +134,7 @@ One string has special characters, the other one has accents.
            {
              "text": "Nação Rubro Negra"
            }
-      },      
-      
+      }
     ]
 }
 ```


### PR DESCRIPTION
Had an error when copy/paste the Sample Input into Postman which was from an extra comma at the end of the Sample Input blocks.